### PR TITLE
refactor: use BlockExcMode enum

### DIFF
--- a/neverust-core/src/config.rs
+++ b/neverust-core/src/config.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use thiserror::Error;
 
+use crate::blockexc::BlockExcMode;
+
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("IO error: {0}")]
@@ -53,8 +55,8 @@ pub struct StartCommand {
     pub api_port: u16,
 
     /// Node operating mode: altruistic (free blocks) or marketplace (paid blocks)
-    #[arg(long, default_value = "altruistic")]
-    pub mode: String,
+    #[arg(long)]
+    pub mode: BlockExcMode,
 
     /// Price per byte in marketplace mode (in smallest currency unit)
     #[arg(long, default_value_t = 1)]
@@ -78,8 +80,7 @@ pub struct Config {
     pub log_level: String,
     #[serde(default)]
     pub bootstrap_nodes: Vec<String>,
-    pub mode: String,
-    pub price_per_byte: u64,
+    pub mode: BlockExcMode,
 }
 
 impl Default for Config {
@@ -91,8 +92,7 @@ impl Default for Config {
             api_port: 8080,
             log_level: "info".to_string(),
             bootstrap_nodes: Vec::new(),
-            mode: "altruistic".to_string(),
-            price_per_byte: 1,
+            mode: BlockExcMode::MarketPlace { price_per_byte: 1 }
         }
     }
 }
@@ -252,7 +252,6 @@ impl From<StartCommand> for Config {
             log_level: cmd.log_level,
             bootstrap_nodes: cmd.bootstrap_node,
             mode: cmd.mode,
-            price_per_byte: cmd.price_per_byte,
         }
     }
 }

--- a/neverust-core/src/p2p.rs
+++ b/neverust-core/src/p2p.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 
-use crate::blockexc::BlockExcBehaviour;
+use crate::blockexc::{BlockExcMode, BlockExcBehaviour };
 use crate::identify_shim::{IdentifyBehaviour, IdentifyConfig};
 use crate::storage::BlockStore;
 
@@ -66,8 +66,7 @@ impl From<void::Void> for BehaviourEvent {
 /// Returns (swarm, block_request_tx, keypair)
 pub async fn create_swarm(
     block_store: Arc<BlockStore>,
-    mode: String,
-    price_per_byte: u64,
+    mode: BlockExcMode,
     metrics: crate::metrics::Metrics,
 ) -> Result<
     (
@@ -97,7 +96,7 @@ pub async fn create_swarm(
     tracing::info!(
         "Local peer ID: {} (mode: {}, key: secp256k1)",
         peer_id,
-        mode
+        mode.mode_string()
     );
 
     // Create Identify config using our custom shim for nim-libp2p compatibility
@@ -119,7 +118,7 @@ pub async fn create_swarm(
 
     // Create behavior: BlockExc + Identify
     let (blockexc_behaviour, block_request_tx) =
-        BlockExcBehaviour::new(block_store, mode, price_per_byte, metrics);
+        BlockExcBehaviour::new(block_store, mode, metrics);
     let behaviour = Behaviour {
         blockexc: blockexc_behaviour,
         identify: identify_behaviour,

--- a/neverust-core/src/runtime.rs
+++ b/neverust-core/src/runtime.rs
@@ -40,7 +40,6 @@ pub async fn run_node(config: Config) -> Result<(), P2PError> {
     let (mut swarm, block_request_tx, keypair) = create_swarm(
         block_store.clone(),
         config.mode.clone(),
-        config.price_per_byte,
         metrics.clone(),
     )
     .await?;

--- a/tests/block_exchange_test.rs
+++ b/tests/block_exchange_test.rs
@@ -2,7 +2,7 @@
 
 use futures_util::StreamExt;
 use libp2p::Multiaddr;
-use neverust_core::{create_swarm, Block, BlockStore, Metrics};
+use neverust_core::{blockexc::BlockExcMode, create_swarm, Block, BlockStore, Metrics};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -24,9 +24,9 @@ async fn test_two_nodes_exchange_blocks() -> Result<(), Box<dyn std::error::Erro
 
     // Create two swarms (nodes) with their block stores
     let (mut swarm1, _tx1, _keypair1) =
-        create_swarm(store1.clone(), "altruistic".to_string(), 0, metrics1).await?;
+        create_swarm(store1.clone(), BlockExcMode::Altruistic, metrics1).await?;
     let (mut swarm2, _tx2, _keypair2) =
-        create_swarm(store2.clone(), "altruistic".to_string(), 0, metrics2).await?;
+        create_swarm(store2.clone(), BlockExcMode::Altruistic, metrics2).await?;
 
     let peer1_id = *swarm1.local_peer_id();
     let peer2_id = *swarm2.local_peer_id();
@@ -166,7 +166,7 @@ async fn test_retrieve_from_testnet() -> Result<(), Box<dyn std::error::Error>> 
 
     // Create swarm (node) with block store
     let (mut swarm, block_request_tx, _keypair) =
-        create_swarm(store.clone(), "altruistic".to_string(), 0, metrics.clone()).await?;
+        create_swarm(store.clone(), BlockExcMode::Altruistic, metrics.clone()).await?;
 
     let local_peer_id = *swarm.local_peer_id();
     tracing::info!("Local peer ID: {}", local_peer_id);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,7 +5,7 @@
 
 use futures_util::stream::StreamExt;
 use libp2p::{swarm::SwarmEvent, Multiaddr};
-use neverust_core::{create_swarm, BlockStore, Config, Metrics};
+use neverust_core::{blockexc::BlockExcMode, create_swarm, BlockStore, Config, Metrics};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -54,7 +54,7 @@ async fn test_create_swarm_and_listen() {
     let block_store = Arc::new(BlockStore::new());
     let metrics = Metrics::new();
     let (mut swarm, _tx, _keypair) =
-        create_swarm(block_store, "altruistic".to_string(), 0, metrics)
+        create_swarm(block_store, BlockExcMode::Altruistic, metrics)
             .await
             .expect("Failed to create swarm");
     let peer_id = *swarm.local_peer_id();
@@ -115,7 +115,7 @@ async fn test_dial_bootstrap_node() {
     let block_store = Arc::new(BlockStore::new());
     let metrics = Metrics::new();
     let (mut swarm, _tx, _keypair) =
-        create_swarm(block_store, "altruistic".to_string(), 0, metrics)
+        create_swarm(block_store, BlockExcMode::Altruistic, metrics)
             .await
             .expect("Failed to create swarm");
     let local_peer_id = *swarm.local_peer_id();
@@ -255,7 +255,7 @@ async fn test_connect_and_verify_all_protocols() {
     let block_store = Arc::new(BlockStore::new());
     let metrics = Metrics::new();
     let (mut swarm, _tx, _keypair) =
-        create_swarm(block_store, "altruistic".to_string(), 0, metrics)
+        create_swarm(block_store, BlockExcMode::Altruistic, metrics)
             .await
             .expect("Failed to create swarm");
     info!("📝 Local peer: {}", swarm.local_peer_id());
@@ -430,7 +430,7 @@ async fn test_connect_to_all_bootstrap_nodes() {
         let block_store = Arc::new(BlockStore::new());
         let metrics = Metrics::new();
         let (mut swarm, _tx, _keypair) =
-            create_swarm(block_store, "altruistic".to_string(), 0, metrics)
+            create_swarm(block_store, BlockExcMode::Altruistic, metrics)
                 .await
                 .expect("Failed to create swarm");
 
@@ -510,7 +510,7 @@ async fn test_blockexc_protocol_detailed() {
     let block_store = Arc::new(BlockStore::new());
     let metrics = Metrics::new();
     let (mut swarm, _tx, _keypair) =
-        create_swarm(block_store, "altruistic".to_string(), 0, metrics)
+        create_swarm(block_store, BlockExcMode::Altruistic, metrics)
             .await
             .expect("Failed to create swarm");
     let local_peer_id = *swarm.local_peer_id();

--- a/tests/performance_test.rs
+++ b/tests/performance_test.rs
@@ -1,5 +1,5 @@
 use futures_util::StreamExt;
-use neverust_core::{create_swarm, Block, BlockStore, Metrics};
+use neverust_core::{blockexc::BlockExcMode, create_swarm, Block, BlockStore, Metrics};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::time::{timeout, Duration};
@@ -18,10 +18,10 @@ async fn test_peer_dial_latency() {
     let metrics1 = Metrics::new();
     let metrics2 = Metrics::new();
 
-    let (mut swarm1, _tx1, _keypair1) = create_swarm(store1, "altruistic".to_string(), 0, metrics1)
+    let (mut swarm1, _tx1, _keypair1) = create_swarm(store1, BlockExcMode::Altruistic, metrics1)
         .await
         .expect("Failed to create swarm1");
-    let (mut swarm2, _tx2, _keypair2) = create_swarm(store2, "altruistic".to_string(), 0, metrics2)
+    let (mut swarm2, _tx2, _keypair2) = create_swarm(store2, BlockExcMode::Altruistic, metrics2)
         .await
         .expect("Failed to create swarm2");
 
@@ -87,11 +87,11 @@ async fn test_content_fetch_latency() {
     let metrics2 = Metrics::new();
 
     let (mut swarm1, _tx1, _keypair1) =
-        create_swarm(store1.clone(), "altruistic".to_string(), 0, metrics1)
+        create_swarm(store1.clone(), BlockExcMode::Altruistic, metrics1)
             .await
             .expect("Failed to create swarm1");
     let (mut swarm2, _tx2, _keypair2) =
-        create_swarm(store2.clone(), "altruistic".to_string(), 0, metrics2)
+        create_swarm(store2.clone(), BlockExcMode::Altruistic, metrics2)
             .await
             .expect("Failed to create swarm2");
 
@@ -165,11 +165,11 @@ async fn test_peer_dial_p95() {
         let metrics2 = Metrics::new();
 
         let (mut swarm1, _tx1, _keypair1) =
-            create_swarm(store1, "altruistic".to_string(), 0, metrics1)
+            create_swarm(store1, BlockExcMode::Altruistic, metrics1)
                 .await
                 .expect("Failed to create swarm1");
         let (mut swarm2, _tx2, _keypair2) =
-            create_swarm(store2, "altruistic".to_string(), 0, metrics2)
+            create_swarm(store2, BlockExcMode::Altruistic, metrics2)
                 .await
                 .expect("Failed to create swarm2");
 


### PR DESCRIPTION
replaces the use of string to differenciate between marketplace and altruistic mode for block exc with an enum